### PR TITLE
Typo fixes for VCF header.

### DIFF
--- a/src/bin/multi-wham-testing.cpp
+++ b/src/bin/multi-wham-testing.cpp
@@ -162,14 +162,14 @@ void printHeader(void){
   cout << "##INFO=<ID=AF,Number=3,Type=Float,Description=\"Allele frequency of: background,target,combined\">" << endl;
   cout << "##INFO=<ID=GC,Number=2,Type=Integer,Description=\"Number of called genotypes in: background,target\">"  << endl;
   cout << "##INFO=<ID=CU,Number=1,Type=Integer,Description=\"Number of neighboring soft clip clusters across all individuals at pileup position \">" << endl;
-  cout << "##INFO=<ID=ED,Numper=.,Type=String,Description=\"Colon separated list of potenial paired breakpoints, in the format: seqid,pos\">" << endl;
+  cout << "##INFO=<ID=ED,Number=.,Type=String,Description=\"Colon separated list of potenial paired breakpoints, in the format: seqid,pos\">" << endl;
   cout << "##INFO=<ID=BE,Number=2,Type=String,Description=\"Best end position: chr, position\">"                  << endl;
   cout << "##INFO=<ID=NC,Number=1,Type=String,Description=\"Number of soft clipped sequences collapsed into consensus\">"                  << endl;
   cout << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Pseudo genotype\">"                                                                 << endl;
   cout << "##FORMAT=<ID=GL,Number=A,Type=Float,Description=\"Genotype likelihood \">"                                                                 << endl;
   cout << "##FORMAT=<ID=FR,Number=1,Type=Float,Description=\"Fraction of reads with soft or hard clipping\">"                                << endl;
-  cout << "##FORMAT=<ID=NR,Number=1,Type=Integer,Description=\"Number of reads supporting no SV\">"                                                      << endl;
-  cout << "##FORMAT=<ID=NA,Number=1,Type=Integer,Description=\"Number of reads supporting no SV\">"                                                      << endl;
+  cout << "##FORMAT=<ID=NR,Number=1,Type=Integer,Description=\"Number of reads supporting a SV\">"                                                      << endl;
+  cout << "##FORMAT=<ID=NA,Number=1,Type=Integer,Description=\"Number of reads that do not support a SV\">"                                                      << endl;
   cout << "##FORMAT=<ID=CL,Number=1,Type=Integer,Description=\"Number of bases that have been soft clipped\">"                                            << endl;
   cout << "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Number of reads with mapping quality greater than 0\">"                                << endl;
   cout << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT" << "\t";


### PR DESCRIPTION
Zev;
These are a few small fixes with the VCF header. The most important is the s/Numper/Number/ which fixes downstream compatibility with VCF parsing tools.
