### PR TITLE
Small build and debug message fixes

### DIFF
--- a/src/bin/graph-er.cpp
+++ b/src/bin/graph-er.cpp
@@ -4061,7 +4061,7 @@ void gatherBamStats(string & targetfile){
 
   while(i < 8 || n < 100000){
 
-    if((n % 100) == 0){
+    if((n % 10000) == 0 && fail < 10){
       omp_set_lock(&lock);
       cerr << "INFO: processed " << n << " reads for: " << targetfile << endl;
       omp_unset_lock(&lock);

--- a/src/bin/mergeIndv.cpp
+++ b/src/bin/mergeIndv.cpp
@@ -43,6 +43,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <cmath>
 #include "split.h"
+#include <getopt.h>
 
 using namespace std;
 


### PR DESCRIPTION
Zev;
A couple of small issues I ran into when working with the latest WHAM updates

- mergeIndv requires getopt import to compile on CentOS5
- Avoid large number of INFO messages when gatherBamStats does not find
  useful reads.