### PR TITLE
Debugging VCF output: FORMAT, REF alleles and mergeIndvs

### DIFF
--- a/src/bin/graph-er.cpp
+++ b/src/bin/graph-er.cpp
@@ -824,7 +824,7 @@ void printVCF(vector<breakpoints *> & calls, RefVector & seqs){
   header << "##FORMAT=<ID=GL,Number=.,Type=Float,Description=\"Genotype likelihoods comprised of comma separated floating point log10-scaled likelihoods for all possible genotypes given the set of alleles defined in the REF and ALT fields.\">" << endl;
   header << "##FORMAT=<ID=AS,Number=1,Type=Integer,Description=\"Number of reads that align better to ALT allele\">" << endl;
   header << "##FORMAT=<ID=RS,Number=1,Type=Integer,Description=\"Number of reads that align better to REF allele\">" << endl;
-  header << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" ;
+  header << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT" ;
 
   for(vector<string>::iterator iz = globalOpts.targetBams.begin(); iz !=  globalOpts.targetBams.end(); iz++){
 
@@ -4602,7 +4602,7 @@ int main( int argc, char** argv)
 #pragma omp parallel for schedule(dynamic, 3)
    for(unsigned int i = 0 ; i < globalTrees.size(); i++){
      
-     if((i % 1000) == 0){
+     if((i % 100000) == 0){
        omp_set_lock(&glock);     
        cerr << "INFO: Processed " << i << "/" << globalTrees.size() << " trees" << endl;
        omp_unset_lock(&glock);


### PR DESCRIPTION
Zev;
Thanks so much for the VCF output work. I'm testing this right now and ran into a couple of small problems included in this patch. I also ran into a couple of larger issues I wasn't sure how to tackle:

- Missing REF column alleles in the VCF output. GATK rejects VCFs with missing REF alleles (`.`) and I didn't find a tool to quickly add these. I could code up something to add them inside bcbio, but thought it might be something you'd rather have in the default VCF output from WHAM. Would this be possible to add to the output?

- mergeIndvs throws away genotypes right now, which looks like it is intentional (https://github.com/jewmanchue/wham/commit/8ea3e431da29c9fc93dd6e3817684c12a8d215f4). This creates invalid VCF if you apply it to non-genotyped VCF output. For now I'm just skipping mergeIndvs, but just as a heads up in case you were not already aware.

Thanks again.