### PR TITLE
GATK compatible GLs in VCF output

### DIFF
--- a/src/bin/graph-er.cpp
+++ b/src/bin/graph-er.cpp
@@ -946,8 +946,6 @@ void printVCF(vector<breakpoints *> & calls, RefVector & seqs){
       for(unsigned int i = 0; i < (*c)->genotypeIndex.size(); i++){
 	if((*c)->genotypeIndex[i] == -1){
 	  ss << "\t" << "./.:" << "."
-	     << "," << "."
-	     << "," << "."
 	     << ":" << (*c)->nalt[i]
 	     << ":" << (*c)->nref[i];
 	}


### PR DESCRIPTION
Zev;
This is one more small fix for GATK compatible VCF output. GATK expects empty GL output to be just a `.` instead of `.,.,.`. The later causes it to die. With this fix everything looks smooth with both VCF output and recalling. Thanks again for all this work getting VCF up and running.