### PR TITLE
Fix the seed of random num generator

### DIFF
--- a/src/bin/wham.cpp
+++ b/src/bin/wham.cpp
@@ -2768,7 +2768,7 @@ int main(int argc, char** argv) {
 
   omp_init_lock(&lock);
 
-  srand((unsigned)time(NULL));
+  srand(10);
 
   globalOpts.nthreads = -1;
 


### PR DESCRIPTION
This PR fixes the issue discussed in https://github.com/zeeev/wham/issues/51

The PR fixes the random number seed to a const (e.g., `10), which results in reproducible output. 

